### PR TITLE
Sync to upstream SVF: LLVM 21.1.0, drop deadsnakes PPA

### DIFF
--- a/.github/workflows/ssa.yml
+++ b/.github/workflows/ssa.yml
@@ -89,7 +89,7 @@ jobs:
       working-directory: teaching
       run: |
         export SVF_DIR=$(npm root)/SVF
-        export LLVM_DIR=$(npm root)/llvm-18.1.0.obj
+        export LLVM_DIR=$(npm root)/llvm-21.1.0.obj
         export Z3_DIR=$(npm root)/z3.obj
         echo "SVF_DIR="$SVF_DIR
         echo "LLVM_DIR="$LLVM_DIR

--- a/.github/workflows/tsa.yml
+++ b/.github/workflows/tsa.yml
@@ -59,7 +59,7 @@ jobs:
       working-directory: teaching
       run: |
         export SVF_DIR=$(npm root)/SVF
-        export LLVM_DIR=$(npm root)/llvm-18.1.0.obj
+        export LLVM_DIR=$(npm root)/llvm-21.1.0.obj
         export Z3_DIR=$(npm root)/z3.obj
         echo "SVF_DIR="$SVF_DIR
         echo "LLVM_DIR="$LLVM_DIR

--- a/.github/workflows/tsv.yml
+++ b/.github/workflows/tsv.yml
@@ -48,15 +48,15 @@ jobs:
       run: |
         npm install svf-lib
 
-    - name: Install Python 3.10 and pysvf
+    - name: Install python3 and pysvf
       run: |
-        # Add deadsnakes PPA for multiple Python versions
-        sudo add-apt-repository ppa:deadsnakes/ppa
-        sudo apt-get update
-        sudo apt-get install -y python3.10-dev python3-pip
-        sudo update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.10 1
-        python3 -m pip install pysvf -i https://test.pypi.org/simple/
-        python3 -m pip install z3-solver
+        # Use the python3 that ships with the Ubuntu runner. We previously pulled
+        # python3.10 from ppa:deadsnakes/ppa, but Launchpad has been intermittently
+        # unreachable (HTTP 504 from add-apt-repository), and SVF does not pin a
+        # Python version.
+        sudo apt-get install -y python3-dev python3-pip
+        python3 -m pip install --break-system-packages pysvf -i https://test.pypi.org/simple/
+        python3 -m pip install --break-system-packages z3-solver
 
     - name: Replace assignments with solutions
       run: |
@@ -73,7 +73,7 @@ jobs:
       working-directory: teaching
       run: |
         export SVF_DIR=$(npm root)/SVF
-        export LLVM_DIR=$(npm root)/llvm-18.1.0.obj
+        export LLVM_DIR=$(npm root)/llvm-21.1.0.obj
         export Z3_DIR=$(npm root)/z3.obj
         echo "SVF_DIR="$SVF_DIR
         echo "LLVM_DIR="$LLVM_DIR


### PR DESCRIPTION
Match the upstream SVF/build.sh pin (MajorLLVMVer=21) and remove the ppa:deadsnakes/ppa python3.10 install path. Launchpad's PPA infrastructure has been intermittently unreachable from CI runners (HTTP 504 from add-apt-repository), and SVF does not pin a Python version, so the Ubuntu base-image python3 (24.04 = 3.12) is sufficient.