### PR TITLE
Drop ppa:ubuntu-toolchain-r/test from ssa.yml + tsa.yml

### DIFF
--- a/.github/workflows/ssa.yml
+++ b/.github/workflows/ssa.yml
@@ -35,8 +35,6 @@ jobs:
     - name: ubuntu-setup
       run: |
         sudo apt-get update
-        sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
-        sudo apt-get update
         sudo apt-get install cmake gcc g++ nodejs doxygen graphviz lcov libncurses5-dev libtinfo6 libzstd-dev
 
     # Install SVF dependencies

--- a/.github/workflows/tsa.yml
+++ b/.github/workflows/tsa.yml
@@ -35,8 +35,6 @@ jobs:
     - name: ubuntu-setup
       run: |
         sudo apt-get update
-        sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
-        sudo apt-get update
         sudo apt-get install cmake gcc g++ nodejs doxygen graphviz lcov libncurses5-dev libtinfo6 libzstd-dev
 
     # Install SVF dependencies


### PR DESCRIPTION
## Summary
- `ssa.yml` and `tsa.yml` still ran `sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test`, which intermittently 504s against Launchpad and breaks the CI.
- Ubuntu 24.04 ships gcc-13 in the base image, so this PPA isn't needed.
- `tsv.yml` was already clean from an earlier round.

## Test plan
- [x] `python3 -c "import yaml; yaml.safe_load(open('ssa.yml'))"` — YAML still valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)