### PR TITLE
Switch pysvf install from TestPyPI to PyPI

### DIFF
--- a/.github/workflows/ssa.yml
+++ b/.github/workflows/ssa.yml
@@ -54,7 +54,7 @@ jobs:
       run: |
         pip install --upgrade pip
         pip install wheel pybind11 notebook nbconvert nbclient ipykernel build z3-solver
-        pip install pysvf -i https://test.pypi.org/simple/
+        pip install pysvf
 
     - name: Replace assignments with solutions
       run: |

--- a/.github/workflows/tsv.yml
+++ b/.github/workflows/tsv.yml
@@ -55,7 +55,7 @@ jobs:
         # unreachable (HTTP 504 from add-apt-repository), and SVF does not pin a
         # Python version.
         sudo apt-get install -y python3-dev python3-pip
-        python3 -m pip install --break-system-packages pysvf -i https://test.pypi.org/simple/
+        python3 -m pip install --break-system-packages pysvf
         python3 -m pip install --break-system-packages z3-solver
 
     - name: Replace assignments with solutions


### PR DESCRIPTION
pysvf is now published to PyPI proper (latest 1.0.0.8 from 2026-05-11 contains the AbstractInterpretation.getAEInstance binding and the PR-#1808 CallPE multi-opnd methods).  TestPyPI still serves the older 1.0.0.121 (2026-04-11) which breaks ass2-py (no CallPE.getOpVarNum) and ass3-py (no pysvf.AbstractInterpretation).

Drop the '-i https://test.pypi.org/simple/' override in ssa.yml, tsa.yml (if applicable), and tsv.yml.